### PR TITLE
Update sonar-scanner-cli version to v5.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/m9m8t3a5/sonarsource/sonar-scanner-cli:4.7
+FROM public.ecr.aws/m9m8t3a5/sonarsource/sonar-scanner-cli:5.0.1
 
 LABEL version="0.0.1" \
       repository="https://github.com/sonarsource/sonarcloud-github-action" \


### PR DESCRIPTION
#### Which issue(s) this PR fixes

- https://github.com/quipper/global-issues/issues/438

#### What this PR does / why we need it

A sonarscan job failed due to

> The version of Java (11.0.17) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.
Read more [here](https://docs.sonarcloud.io/appendices/scanner-environment/)

#### Description of changes

Update sonar-scanner-cli version to v5.0.1

#### Supported Information

Later, I will add the workflow for mirroring sonar-scanner-cli image.
But, first I want to confirm if the latest image can resolve this issue. So, I copied sonar-scanner-cli image from dockerhub to ECR Public on my laptop.

```
❯ regctl image copy sonarsource/sonar-scanner-cli:5.0.1 public.ecr.aws/m9m8t3a5/sonarsource/sonar-scanner-cli:5.0.1
Manifests: 1/1 | Blobs: 123.408MB copied, 0.000B skipped | Elapsed: 41s
public.ecr.aws/m9m8t3a5/sonarsource/sonar-scanner-cli:5.0.1
```